### PR TITLE
Generic connection compat

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel"
-version = "1.4.3"
+version = "1.4.4"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
 description = "A safe, extensible ORM and Query Builder for PostgreSQL, SQLite, and MySQL"

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -23,7 +23,9 @@ use crate::query_dsl::RunQueryDsl;
 use crate::query_source::{Column, Table};
 use crate::result::QueryResult;
 #[cfg(feature = "sqlite")]
-use crate::sqlite::{Sqlite, SqliteConnection};
+use crate::sqlite::Sqlite;
+#[cfg(feature = "sqlite")]
+use crate::Connection;
 
 /// The structure returned by [`insert_into`].
 ///
@@ -204,15 +206,15 @@ where
 }
 
 #[cfg(feature = "sqlite")]
-impl<'a, T, U, Op> ExecuteDsl<SqliteConnection> for InsertStatement<T, BatchInsert<'a, U, T>, Op>
+impl<'a, T, U, Op, C> ExecuteDsl<C, Sqlite> for InsertStatement<T, BatchInsert<'a, U, T>, Op>
 where
+    C: Connection<Backend = Sqlite>,
     &'a U: Insertable<T>,
     InsertStatement<T, <&'a U as Insertable<T>>::Values, Op>: QueryFragment<Sqlite>,
     T: Copy,
     Op: Copy,
 {
-    fn execute(query: Self, conn: &SqliteConnection) -> QueryResult<usize> {
-        use crate::connection::Connection;
+    fn execute(query: Self, conn: &C) -> QueryResult<usize> {
         conn.transaction(|| {
             let mut result = 0;
             for record in query.records.records {
@@ -286,15 +288,15 @@ where
 }
 
 #[cfg(feature = "sqlite")]
-impl<T, U, Op> ExecuteDsl<SqliteConnection>
+impl<T, U, Op, C> ExecuteDsl<C, Sqlite>
     for InsertStatement<T, OwnedBatchInsert<ValuesClause<U, T>, T>, Op>
 where
+    C: Connection<Backend = Sqlite>,
     InsertStatement<T, ValuesClause<U, T>, Op>: QueryFragment<Sqlite>,
     T: Copy,
     Op: Copy,
 {
-    fn execute(query: Self, conn: &SqliteConnection) -> QueryResult<usize> {
-        use crate::connection::Connection;
+    fn execute(query: Self, conn: &C) -> QueryResult<usize> {
         conn.transaction(|| {
             let mut result = 0;
             for value in query.records.values {

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -212,6 +212,29 @@ where
     }
 }
 
+impl<M> crate::migration::MigrationConnection for PooledConnection<M>
+where
+    M: ManageConnection,
+    M::Connection: crate::migration::MigrationConnection,
+    Self: Connection,
+{
+    fn setup(&self) -> QueryResult<usize> {
+        (&**self).setup()
+    }
+}
+
+impl<Changes, Output, M> crate::query_dsl::UpdateAndFetchResults<Changes, Output>
+    for PooledConnection<M>
+where
+    M: ManageConnection,
+    M::Connection: crate::query_dsl::UpdateAndFetchResults<Changes, Output>,
+    Self: Connection,
+{
+    fn update_and_fetch(&self, changeset: Changes) -> QueryResult<Output> {
+        (&**self).update_and_fetch(changeset)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc;

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -16,8 +16,7 @@ use std::convert::Into;
 use std::fmt;
 use std::marker::PhantomData;
 
-use crate::backend::UsesAnsiSavepointSyntax;
-use crate::connection::{AnsiTransactionManager, SimpleConnection};
+use crate::connection::{SimpleConnection, TransactionManager};
 use crate::deserialize::{Queryable, QueryableByName};
 use crate::prelude::*;
 use crate::query_builder::{AsQuery, QueryFragment, QueryId};
@@ -128,12 +127,10 @@ where
 impl<M> Connection for PooledConnection<M>
 where
     M: ManageConnection,
-    M::Connection:
-        Connection<TransactionManager = AnsiTransactionManager> + R2D2Connection + Send + 'static,
-    <M::Connection as Connection>::Backend: UsesAnsiSavepointSyntax,
+    M::Connection: Connection + R2D2Connection + Send + 'static,
 {
     type Backend = <M::Connection as Connection>::Backend;
-    type TransactionManager = <M::Connection as Connection>::TransactionManager;
+    type TransactionManager = PooledConnectionTransactionManager<M>;
 
     fn establish(_: &str) -> ConnectionResult<Self> {
         Err(ConnectionError::BadConnection(String::from(
@@ -171,7 +168,47 @@ where
     }
 
     fn transaction_manager(&self) -> &Self::TransactionManager {
-        (&**self).transaction_manager()
+        // This is actually fine because we have an #[repr(transparent)]
+        // on LoggingTransactionManager, which means the layout is the same
+        // as the inner type
+        // See the ref-cast crate for a longer version: https://github.com/dtolnay/ref-cast
+        unsafe {
+            &*((&**self).transaction_manager() as *const _ as *const Self::TransactionManager)
+        }
+    }
+}
+
+#[doc(hidden)]
+#[repr(transparent)]
+#[allow(missing_debug_implementations)]
+pub struct PooledConnectionTransactionManager<M>
+where
+    M: ManageConnection,
+    M::Connection: Connection,
+{
+    inner: <M::Connection as Connection>::TransactionManager,
+}
+
+impl<M> TransactionManager<PooledConnection<M>> for PooledConnectionTransactionManager<M>
+where
+    M: ManageConnection,
+    PooledConnection<M>: Connection,
+    M::Connection: Connection,
+{
+    fn begin_transaction(&self, conn: &PooledConnection<M>) -> QueryResult<()> {
+        self.inner.begin_transaction(&**conn)
+    }
+
+    fn rollback_transaction(&self, conn: &PooledConnection<M>) -> QueryResult<()> {
+        self.inner.rollback_transaction(&**conn)
+    }
+
+    fn commit_transaction(&self, conn: &PooledConnection<M>) -> QueryResult<()> {
+        self.inner.commit_transaction(&**conn)
+    }
+
+    fn get_transaction_depth(&self) -> u32 {
+        self.inner.get_transaction_depth()
     }
 }
 

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://diesel.rs"
 
 
 [dependencies]
-migrations_internals = "~1.4.0"
-migrations_macros = "~1.4.0"
+migrations_internals = "=1.4.0"
+migrations_macros = "=1.4.1"
 
 [dev-dependencies]
-diesel = { version = "1.4.0", default-features = false }
+diesel = { version = "=1.4.4", default-features = false }
 dotenv = ">=0.8, <0.11"
 cfg-if = "0.1.0"
 

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -7,7 +7,7 @@ description = "Internal implementation of diesels migration mechanism"
 homepage = "https://diesel.rs"
 
 [dependencies]
-diesel = { version = "~1.4.0", default-features = false }
+diesel = { version = "=1.4.4", default-features = false }
 barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
 
 [dev-dependencies]

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.diesel.rs"
 homepage = "https://diesel.rs"
 
 [dependencies]
-migrations_internals = "~1.4.0"
+migrations_internals = "=1.4.0"
 syn = { version = "1", features = ["extra-traits"] }
 quote = "1"
 proc-macro2 = "1"


### PR DESCRIPTION
Contains code that allows for generic connection implementations and allows us to work with the generic `diesel_logger` implementation.

NB: Ideally it would go in a new branch, but it came from this one, so this is the closest one I could find.